### PR TITLE
Using polkadot-launch, chain field contains the chain name, not the json filename

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"relaychain": {
 		"bin": "./bin/polkadot",
-		"chain": "./rococo-local.json",
+		"chain": "rococo-local",
 		"nodes": [
 			{
 				"name": "alice",


### PR DESCRIPTION
This is what I understood from looking at polkadot-launch script. Let me know if this is not so.
@riusricardo @JesseAbram 