### PR TITLE
Set asset deposits to 1 KSM, 100 DOT

### DIFF
--- a/runtime/statemine/src/constants.rs
+++ b/runtime/statemine/src/constants.rs
@@ -16,8 +16,8 @@
 pub mod currency {
 	use node_primitives::Balance;
 
-	pub const DOTS: Balance = 1_000_000_000_000;
-	pub const DOLLARS: Balance = DOTS / 6;
+	pub const KSM: Balance = 1_000_000_000_000;
+	pub const DOLLARS: Balance = KSM / 300;
 	pub const CENTS: Balance = DOLLARS / 100;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 

--- a/runtime/statemine/src/lib.rs
+++ b/runtime/statemine/src/lib.rs
@@ -313,7 +313,7 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 100 * EXISTENTIAL_DEPOSIT;
+	pub const AssetDeposit: Balance = KSM; // 1 KSM deposit to create asset
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const StringLimit: u32 = 50;
 	/// Key = 32 bytes, Value = 36 bytes (32+1+1+1+1)

--- a/runtime/statemint/src/constants.rs
+++ b/runtime/statemint/src/constants.rs
@@ -17,13 +17,13 @@ pub mod currency {
 	use node_primitives::Balance;
 
 	pub const OLDDOT: Balance = 1_000_000_000_000;
-	pub const NEWDOT: Balance = OLDDOT / 100; // 10_000_000_000
-	pub const CENTS: Balance = NEWDOT / 100; // 100_000_000
+	pub const DOT: Balance = OLDDOT / 100; // 10_000_000_000
+	pub const CENTS: Balance = DOT / 100; // 100_000_000
 	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		// 1/10 of Polkadot v29
-		items as Balance * 2 * NEWDOT + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 2 * DOT + (bytes as Balance) * 10 * MILLICENTS
 	}
 }
 

--- a/runtime/statemint/src/constants.rs
+++ b/runtime/statemint/src/constants.rs
@@ -16,14 +16,14 @@
 pub mod currency {
 	use node_primitives::Balance;
 
-	pub const DOTS: Balance = 1_000_000_000_000;
-	pub const DOLLARS: Balance = DOTS / 100; // 10_000_000_000
-	pub const CENTS: Balance = DOLLARS / 100; // 100_000_000
+	pub const OLDDOT: Balance = 1_000_000_000_000;
+	pub const NEWDOT: Balance = OLDDOT / 100; // 10_000_000_000
+	pub const CENTS: Balance = NEWDOT / 100; // 100_000_000
 	pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		// 1/10 of Polkadot v29
-		items as Balance * 2 * DOLLARS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 2 * NEWDOT + (bytes as Balance) * 10 * MILLICENTS
 	}
 }
 

--- a/runtime/statemint/src/lib.rs
+++ b/runtime/statemint/src/lib.rs
@@ -313,7 +313,7 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 100 * NEWDOT; // 100 DOT deposit to create asset
+	pub const AssetDeposit: Balance = 100 * DOT; // 100 DOT deposit to create asset
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const StringLimit: u32 = 50;
 	/// Key = 32 bytes, Value = 36 bytes (32+1+1+1+1)

--- a/runtime/statemint/src/lib.rs
+++ b/runtime/statemint/src/lib.rs
@@ -313,7 +313,7 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 100 * EXISTENTIAL_DEPOSIT;
+	pub const AssetDeposit: Balance = 100 * NEWDOT; // 100 DOT deposit to create asset
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const StringLimit: u32 = 50;
 	/// Key = 32 bytes, Value = 36 bytes (32+1+1+1+1)


### PR DESCRIPTION
1. Change `DOTS, DOLLARS` to `KSM, OLDDOT, NEWDOT`
2. Set asset creation deposits to 1 KSM and 100 DOT. With existential deposit changing on Kusama, I think it is (a) confusing and (b) too low for asset registration (no incentive to remove unneeded assets).